### PR TITLE
Resolving for when there will be two 2018 papers

### DIFF
--- a/docs/computer-architecture-ii.md
+++ b/docs/computer-architecture-ii.md
@@ -14,7 +14,7 @@ CS3021
 
 ## Questions by Year
 
--   [2018](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS3021-1.PDF)
+-   [Trinity Term - 2018](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS3021-1.PDF)
 -   [2017](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2017/CS/CS3021-1.PDF)
 -   [2016](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2016/CS/CS3021-1.PDF)
 -   [2015](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2015/Annuals%20Dec%2014/CS3201-1.pdf)


### PR DESCRIPTION
Adding "Trinity Term" in front of the 2018 paper as this will be the first year in which there will be two papers from the Year 2018 ( Trinity Term 2017/2018 and Michaelmas Term 2018/2019).