### PR TITLE
1st year 2018 patch

### DIFF
--- a/docs/digital-logic-design.md
+++ b/docs/digital-logic-design.md
@@ -13,6 +13,7 @@ CS1026
 
 ## Questions by Year
 
+-   [2018](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS1026-1.PDF)
 -   [2017](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2017/CS/CS1026-1.PDF)
 -   [2016](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2016/CS/CS1026-1.PDF)
 -   [2015](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2015/CS/CS1026-1.PDF)

--- a/docs/electrotechnology.md
+++ b/docs/electrotechnology.md
@@ -12,6 +12,7 @@ CS1025
 
 ## Questions by Year
 
+-   [2018](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS1025-1.PDF)
 -   [2017](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2017/CS/CS1025-1.PDF)
 -   [2016](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2016/CS/CS1025-1.PDF)
 -   [2015](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2015/CS/CS1025-1.PDF)

--- a/docs/introduction-to-computing.md
+++ b/docs/introduction-to-computing.md
@@ -15,6 +15,8 @@ CS1021 & CS1022
 
 ## Questions by Year
 
+-   [2018 Computing I](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS1021-1.PDF)
+-   [2018 Computing II](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS1022-1.PDF)
 -   [2017 Computing I](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2017/CS/CS1021-1.PDF)
 -   [2017 Computing II](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2017/CS/CS1022-1.PDF)
 -   [2016 Computing I](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2016/CS/CS1021-1.PDF)

--- a/docs/mathematics.md
+++ b/docs/mathematics.md
@@ -12,6 +12,7 @@ CS1003
 
 ## Questions by Year
 
+-   [2018 Mathematics](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS1003-2.PDF)
 -   [2017 Mathematics](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2017/CS/CS1003-2.PDF)
 -   [2016 Mathematics](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2016/CS/CS1003-2.PDF)
 -   [2015 Mathematics I](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2015/CS/CS1001-1.PDF)

--- a/docs/telecommunications-i.md
+++ b/docs/telecommunications-i.md
@@ -12,6 +12,7 @@ CS1031
 
 ## Questions by Year
 
+-   [2018](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS1031-1.PDF)
 -   [2017](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2017/CS/CS1031-1.PDF)
 -   [2016](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2016/CS/CS1031-1.PDF)
 -   [2015](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2015/CS/CS1031-1.PDF)


### PR DESCRIPTION
Complete update of 1st year exam paper links updated to include the 2018 papers.

No links for 2018 intro-to-programming as E-tests have taken over from written exams. 