### PR TITLE
Adding December 2018 exam papers to 4th Year modules

### DIFF
--- a/docs/advanced-computational-linguistics.md
+++ b/docs/advanced-computational-linguistics.md
@@ -13,7 +13,8 @@ CS4LL5
 
 ## Questions by Year
 
--   [2018](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS4LL5-1.PDF)
+-   [2018 - December](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2019/Semester%201%20Papers/CS/CS4LL5-1.PDF)
+-   [2018 - January](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS4LL5-1.PDF)
 -   [2017](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2017/CS/CS4LL5-1.PDF)
 -   [2016](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2016/CS/CS4LL5-1.PDF)
 -   [2015](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2015/Annuals%20Dec%2014/CS4LL51-1.pdf)

--- a/docs/computer-graphics.md
+++ b/docs/computer-graphics.md
@@ -12,7 +12,8 @@ CS4052
 
 ## Questions by Year
 
--   [2018](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS4052-1.PDF)
+-   [2018 - December](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2019/Semester%201%20Papers/CS/CS4052-1.PDF)
+-   [2018 - January](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS4052-1.PDF)
 -   [2017](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2017/CS/CS4052-1.PDF)
 -   [2016](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2016/CS/CS4052-1.PDF)
 -   [2015](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2015/CS/CS4052-1.PDF)

--- a/docs/computer-vision.md
+++ b/docs/computer-vision.md
@@ -13,7 +13,8 @@ CS4053
 
 ## Questions by Year
 
--   [2018](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS4053-1.PDF)
+-   [2018 - December](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2019/Semester%201%20Papers/CS/CS4053-1.PDF)
+-   [2018 - January](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS4053-1.PDF)
 -   [2017](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2017/CS/CS4053-1.PDF)
 -   [2016](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2016/CS/CS4053-1.PDF)
 -   [2015](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2015/CS/CS4053-1.PDF)

--- a/docs/formal-verification.md
+++ b/docs/formal-verification.md
@@ -12,7 +12,8 @@ CS4004
 
 ## Questions by Year
 
--   [2018](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS4004-1.PDF)
+-   [2018 - December](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2019/Semester%201%20Papers/CS/CS4004-1.PDF)
+-   [2018 - January](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS4004-1.PDF)
 -   [2017](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2017/CS/CS4004-1.PDF)
 -   [2016](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2016/CS/CS4004-1.PDF)
 -   [2015](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2015/CS/CS4504-1.PDF)

--- a/docs/fuzzy-logic-and-control-systems.md
+++ b/docs/fuzzy-logic-and-control-systems.md
@@ -16,7 +16,8 @@ CS4001
 
 ## Questions by Year
 
--   [2018](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS4001-1.PDF)
+-   [2018 - December](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2019/Semester%201%20Papers/CS/CS4001-1.PDF)
+-   [2018 - January](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS4001-1.PDF)
 -   [2017](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2017/CS/CS4001-1.PDF)
 -   [2016](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2016/CS/CS4001-1.PDF)
 -   [2015](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2015/CS/CS4001-1.PDF)

--- a/docs/human-factors.md
+++ b/docs/human-factors.md
@@ -13,7 +13,8 @@ CS4051
 
 ## Questions by Year
 
--   [2018](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS4051-1.PDF)
+-   [2018 - December](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2019/Semester%201%20Papers/CS/CS4051-1.PDF)
+-   [2018 - January](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS4051-1.PDF)
 -   [2017](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2017/CS/CS4051-1.PDF)
 -   [2016](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2016/CS/CS4051-1.PDF)
 -   [2015](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2015/CS/CS4051-1.PDF)

--- a/docs/machine-learning.md
+++ b/docs/machine-learning.md
@@ -13,7 +13,8 @@ CS4404
 
 ## Questions by Year
 
-* [2018](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS4404-1.PDF)
+* [2018 - December](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2019/Semester%201%20Papers/CS/CS7CS4-1.pdf)
+* [2018 - January](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS4404-1.PDF)
 * [Sample exam](https://tcd.blackboard.com/bbcswebdav/pid-1138589-dt-content-rid-6438197_1/courses/CS4404-A-SEM101-201819/Example%20Exam%20v2%20--%20without%20answers%281%29.pdf)
 * [Sample exam with answers](https://tcd.blackboard.com/bbcswebdav/pid-1138590-dt-content-rid-6438199_1/courses/CS4404-A-SEM101-201819/Example%20Exam%20v2%20--%20with%20correct%20answers%20and%20comments%282%29.pdf)
 

--- a/docs/next-generation-networks.md
+++ b/docs/next-generation-networks.md
@@ -12,7 +12,8 @@ CS4031
 
 ## Questions by Year
 
--   [2018](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS4031-1.PDF)
+-   [2018 - December](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2019/Semester%201%20Papers/CS/CS7NS3-1.pdf)
+-   [2018 - January](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS4031-1.PDF)
 -   [2017](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2017/CS/CS4031-1.PDF)
 -   [2016](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2016/CS/CS4031-1.PDF)
 -   [2015](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2015/Annuals%20Dec%2014/CS4031-1.pdf)

--- a/docs/topics-in-functional-programming.md
+++ b/docs/topics-in-functional-programming.md
@@ -14,7 +14,8 @@ CS4012
 
 ## Questions by Year
 
--   [2018](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS4012-1.PDF)
+-   [2018 - December](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2019/Semester%201%20Papers/CS/CS4012-1.PDF)
+-   [2018 - January](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS4012-1.PDF)
 -   [2017](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2017/CS/CS4012-2.PDF)
 -   (The module did not run in 2016)
 -   [2015](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2015/Annuals%20Dec%2014/CS4012-1.pdf)


### PR DESCRIPTION
Changed the 2018 papers to 2018 - January, and the new papers are 2018 - December. This is to differentiate between the two academic years the papers are from, even though they were in the same calendar year.