### PR TITLE
Added 2019 & 2020 Symbolic Programming exams

### DIFF
--- a/website/docs/symbolic-programming.md
+++ b/website/docs/symbolic-programming.md
@@ -11,6 +11,8 @@ CS3011
 
 ## Questions by Year
 
+-   [2020/21](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers%20202021/CSU/CSU34011-1.pdf)
+-   [2019/20](https://www.tcd.ie/academicregistry/exams/assets/local/past%20papers201920/CSU/CSU34011-1.PDF)
 -   [2018](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS3011-1.PDF)
 -   [2017](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2017/CS/CS3011-1.PDF)
 -   [2016](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2016/CS/CS3011-1.PDF)


### PR DESCRIPTION
Added two most recent Symbolic Programming exams from TCD Academic Registry online past exam papers archive, namely 2019/20 Semester 1 exam and 2020/21 Semester 1 exam.