### PR TITLE
Adding a solutions to SSE with a link to my year 3 solutions github

### DIFF
--- a/website/docs/concurrent-systems-i.md
+++ b/website/docs/concurrent-systems-i.md
@@ -9,6 +9,7 @@ CSU33014
 ## Resources
 
 -   [Module page](https://www.cs.tcd.ie/David.Gregg/cs3014/)
+-   [Alex's SSE solutions](https://github.com/alexandersep/Year3-ICS-Solutions/tree/main/Concurrent-Systems/SSE)
 
 ## Questions by Year
 


### PR DESCRIPTION
My link has 13 years of SSE solutions.

GitHub actions uses the code to check that the commit ensures  compilation of the files. 

The code is testable by compiling a make file and running the main file. Each year the main file will compare against vectorised and non vectorised code with the difference for comparison.