### PR TITLE
Added 2023 and 2022 papers to `algorithms-and-data-structures.md`

### DIFF
--- a/website/docs/algorithms-and-data-structures.md
+++ b/website/docs/algorithms-and-data-structures.md
@@ -16,7 +16,6 @@ CSU22011/CSU22012
 ## Questions by Year
 
 -   [2023](https://www.tcd.ie/academicregistry/exams/assets/local/Past%20Papers%202023-2024/Semester%201/CSU%20CS7%20STU%20STP/CSU22011-1.pdf)
--   [2022](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers202223/CSU/CSU22061-1.pdf)
 -   [2020/21](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers%20202021/CSU/CSU22011-1.pdf)
 -   [2019](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2019/Semester%202%20Papers/CS/CS2010-2.PDF)
 -   [2018](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS2010-1.PDF)

--- a/website/docs/algorithms-and-data-structures.md
+++ b/website/docs/algorithms-and-data-structures.md
@@ -15,6 +15,8 @@ CSU22011/CSU22012
 
 ## Questions by Year
 
+-   [2023](https://www.tcd.ie/academicregistry/exams/assets/local/Past%20Papers%202023-2024/Semester%201/CSU%20CS7%20STU%20STP/CSU22011-1.pdf)
+-   [2022](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers202223/CSU/CSU22061-1.pdf)
 -   [2020/21](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers%20202021/CSU/CSU22011-1.pdf)
 -   [2019](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2019/Semester%202%20Papers/CS/CS2010-2.PDF)
 -   [2018](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2018/CS/CS2010-1.PDF)


### PR DESCRIPTION
Added links to the pdfs for the Algorithms & Data Structures past papers for years 2023 and 2022.