### PR TITLE
Add algorithms and data structures 2 page

### DIFF
--- a/website/docs/algorithms-and-data-structures-i.md
+++ b/website/docs/algorithms-and-data-structures-i.md
@@ -1,10 +1,9 @@
 ---
-id: algorithms-and-data-structures
-title: Algorithms & Data Structures
-sidebar_label: Algorithms & Data Structures
+id: algorithms-and-data-structures-i
+title: Algorithms & Data Structures 1
+sidebar_label: Algorithms & Data Structures 1
 ---
-CS2010
-CSU22011/CSU22012
+CSU22011
 
 ## Resources
 

--- a/website/docs/algorithms-and-data-structures-ii.md
+++ b/website/docs/algorithms-and-data-structures-ii.md
@@ -1,0 +1,27 @@
+---
+id: algorithms-and-data-structures-ii
+title: Algorithms & Data Structures 2
+sidebar_label: Algorithms & Data Structures 2
+---
+CSU22012
+
+## Resources
+
+-   [Blackboard](https://tcd.blackboard.com/ultra/courses/_92842_1/cl/outline)
+-   [Luke's Notes (2025)](https://baileylutcd.github.io/csu22012-algorithms-and-data-structures-2/Notes/README)
+
+## Questions by Year
+
+-   [2024](https://github.com/baileyluTCD/csu22012-algorithms-and-data-structures-2/blob/90c105e09ad8411b0d80d25930fbfcc6e11271f0/Past%20Papers/tcd-examination-paper-CSU22012-2024.pdf)
+-   [2023](https://github.com/baileyluTCD/csu22012-algorithms-and-data-structures-2/blob/90c105e09ad8411b0d80d25930fbfcc6e11271f0/Past%20Papers/tcd-examination-paper-CSU22012-2023.pdf)
+
+## Related Previous Modules
+
+-   [Data Structures 2019/20](https://www.tcd.ie/academicregistry/exams/assets/local/past%20papers201920/CSU/CSU33D05-1.PDF)
+-   [Data Structures and Algorithms 2018/19](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2019/Semester%201%20Papers/CS/CS3D5A-1.PDF)
+-   [Programming Techniques I 2015](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2015/CS/CS2011-2.PDF)
+-   [Programming Techniques I 2014](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2014/CS/CS20112.pdf)
+-   [Programming Techniques II 2015](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2015/CS/CS2012-1.PDF)
+-   [Programming Techniques II 2014](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2014/CS/CS20121.pdf)
+-   [Programming Techniques II 2013](https://www.tcd.ie/academicregistry/exams/assets/local/past-papers2013/CS/CS20121.pdf)
+-   [Programming Techniques 2012](https://www.tcd.ie/Local/Exam_Papers/2012/XC/XCS20111.pdf)

--- a/website/docs/second-year.md
+++ b/website/docs/second-year.md
@@ -5,7 +5,8 @@ sidebar_label: Second Year
 ---
 ## Modules
 
--   [Algorithms & Data Structures](/docs/algorithms-and-data-structures)
+-   [Algorithms & Data Structures I](/docs/algorithms-and-data-structures-i)
+-   [Algorithms & Data Structures II](/docs/algorithms-and-data-structures-ii)
 -   [Applied Probability I](/docs/applied-probability-i)
 -   [Applied Probability II](/docs/applied-probability-ii)
 -   [Computer Architecture I](/docs/computer-architecture-i)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -39,7 +39,8 @@ module.exports = {
       },
       collapsed: true,
       items: [
-        'algorithms-and-data-structures',
+        'algorithms-and-data-structures-i',
+        'algorithms-and-data-structures-ii',
         'applied-probability-i',
         'applied-probability-ii',
         'computer-architecture-i',


### PR DESCRIPTION
At some point (?) the original algorithms and data structures module was split into algorithms and data structures 1 and 2 respectively.

This PR renames the existing algorithms and data structures page to "Algorithms and Data Structures 1" and creates a new "Algorithms and Data Structures 2" repository.

Additionally it should be noted that neither the 2024 or 2023 past papers for this exam are on the tcd past papers website, but instead were provided by the lecturer, hence I am hosting them on my own notes repository.